### PR TITLE
Remove the `result` variable for `sleep_insert()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,13 +311,13 @@ reinserts it at a given position in the queue.
 Similarly as for `sleep_insert()`, this can be useful to achieve
 certain scheduling goals.
 
-### `task_switch(task, sleep_pos=None)`
+### `task_switch(task, *, insert_pos=None)`
 
 Immediately moves the given task to the head of the ready queue and switches to it, assuming it is runnable.
-If `sleep_pos is not None`, the current task will be
+If `insert_pos is not None`, the current task will be
 put to sleep at that position, using `sleep_insert()`. Otherwise the current task is put at the end
-of the ready queue.  If `sleep_pos == 1` the current task will be inserted directly after the target
-task, making it the next to be run.  If `sleep_pos == 0`, the current task will execute _before_ the target.
+of the ready queue.  If `insert_pos == 1` the current task will be inserted directly after the target
+task, making it the next to be run.  If `insert_pos == 0`, the current task will execute _before_ the target.
 
 ### `task_is_blocked(task)`
 

--- a/README.md
+++ b/README.md
@@ -311,12 +311,13 @@ reinserts it at a given position in the queue.
 Similarly as for `sleep_insert()`, this can be useful to achieve
 certain scheduling goals.
 
-### `task_switch(task, result=None, sleep_pos=None)`
+### `task_switch(task, sleep_pos=None)`
 
 Immediately moves the given task to the head of the ready queue and switches to it, assuming it is runnable.
-When this call returns, returns `result`. If `sleep_pos is not None`, the current task will be
+If `sleep_pos is not None`, the current task will be
 put to sleep at that position, using `sleep_insert()`. Otherwise the current task is put at the end
-of the ready queue.
+of the ready queue.  If `sleep_pos == 1` the current task will be inserted directly after the target
+task, making it the next to be run.  If `sleep_pos == 0`, the current task will execute _before_ the target.
 
 ### `task_is_blocked(task)`
 

--- a/src/asynkit/eventloop.py
+++ b/src/asynkit/eventloop.py
@@ -96,16 +96,15 @@ class SchedulingMixin(_Base):
                 return len(self._ready) - i - 1
         raise ValueError("task not in ready queue")
 
-    def ready_get_tasks(self):
+    def ready_tasks(self):
         """
-        Find all runnable tasks in the ready queue. Return a list of
-        (task, index) tuples.
+        Return a set of all all runnable tasks in the ready queue.
         """
-        result = []
-        for i, handle in enumerate(self._ready):
+        result = set()
+        for handle in self._ready:
             task = task_from_handle(handle)
             if task:
-                result.append((task, i))
+                result.add(task)
         return result
 
 
@@ -236,8 +235,8 @@ def runnable_tasks(loop=None):
     """Return a set of the runnable tasks for the loop."""
     if loop is None:
         loop = events.get_running_loop()
-    tasks = loop.ready_get_tasks()
-    result = set(t for (t, _) in tasks)
+    tasks = loop.ready_tasks()
+    result = set(tasks)
     assert all(not task_is_blocked(task) for task in result)
     return result
 

--- a/src/asynkit/eventloop.py
+++ b/src/asynkit/eventloop.py
@@ -143,7 +143,7 @@ def event_loop_policy(policy=None):
         asyncio.set_event_loop_policy(previous)
 
 
-async def sleep_insert(pos, result=None):
+async def sleep_insert(pos):
     """Coroutine that completes after `pos` other callbacks have been run.
 
     This effectively pauses the current coroutine and places it at position `pos`
@@ -159,7 +159,7 @@ async def sleep_insert(pos, result=None):
 
     # make the callback execute right after the current task goes to sleep
     loop.call_insert(0, post_sleep)
-    return await asyncio.sleep(0, result)
+    await asyncio.sleep(0)
 
 
 def task_reinsert(task, pos):
@@ -172,7 +172,7 @@ def task_reinsert(task, pos):
     loop.ready_insert(pos, item)
 
 
-async def task_switch(task, result=None, sleep_pos=None):
+async def task_switch(task, sleep_pos=None):
     """Switch immediately to the given task.
     The target task is moved to the head of the queue. If 'sleep_pos'
     is None, then the current task is scheduled at the end of the
@@ -187,11 +187,11 @@ async def task_switch(task, result=None, sleep_pos=None):
     loop.ready_insert(0, loop.ready_pop(pos))
     if sleep_pos is None:
         # schedule ourselves to the end
-        return await asyncio.sleep(0, result=result)
+        await asyncio.sleep(0)
     else:
         # schedule ourselves at a given position, typically
         # position 1, right after the task.
-        return await sleep_insert(sleep_pos, result=result)
+        await sleep_insert(sleep_pos)
 
 
 def task_is_blocked(task):

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -342,13 +342,8 @@ class TestTasks:
     async def test_get_task(self):
         tasks = self.tasks()
         loop = asyncio.get_running_loop()
-        tasks2 = loop.ready_get_tasks()
-
-        # sort by position for safety
-        tasks2.sort(key=lambda t: t[1])
-
-        tasks3 = [t for t, _ in tasks2]
-        assert tasks3 == tasks
+        tasks2 = loop.ready_tasks()
+        assert tasks2 == set(tasks)
 
     async def test_runnable_tasks(self):
         tasks = self.tasks()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -235,7 +235,7 @@ async def test_task_switch_insert(pos):
         tasks.append(asyncio.create_task(foo(i)))
 
     assert len(log) == 0
-    await asynkit.task_switch(tasks[pos], sleep_pos=1)
+    await asynkit.task_switch(tasks[pos], insert_pos=1)
     log.append("me")
     await asyncio.sleep(0)
     assert len(log) == 7


### PR DESCRIPTION
`asyncio.sleep()` has an optional `result` argument which is just there for convenience if the intent is to replace an actual async call with sleep for testing purposes.

We remove this weird special case.  We also rename and clean up some other methods for consistency.