### PR TITLE
add the coro_iter() utility

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+* Add the coro_iter() helper
 * Move Task creation out of the `CoroStart` class and into `coro_eager()` helper.
 * Add Monitor class and GeneratorObject
 * Add anyio support for testing.  Add asykit.experimental.anyio.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ async def main():
 This is similar to `contextvars.Context.run()` but works for async functions.  This function is
 implemented using `CoroStart`
 
+## `coro_iter` - helper for `__iter__()` methods
+
+This helper function returns an `Generator` for a coroutine.  This is useful, if one
+wants to make an object awaitable via the `__await__` method which must only
+return `Iterator` objects.
+
+```python
+class Awaitable:
+    def __init__(self, coro):
+        self.coro = coro
+    def __await__(self):
+        return asynkit.coro_iter(self.coro)
+
+async def main():
+    await Awaitable(asyncio.sleep(1))
+
+asyncio.run(main())
+```
+
 ## `Monitor`
 
 A `Monitor` object can be used to await a coroutine, while listening for _out of band_ messages

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ implemented using `CoroStart`
 ## `coro_iter` - helper for `__iter__()` methods
 
 This helper function returns an `Generator` for a coroutine.  This is useful, if one
-wants to make an object awaitable via the `__await__` method which must only
+wants to make an object _awaitable_ via the `__await__` method, which must only
 return `Iterator` objects.
 
 ```python
@@ -164,7 +164,8 @@ class Awaitable:
         return asynkit.coro_iter(self.coro)
 
 async def main():
-    await Awaitable(asyncio.sleep(1))
+    a = Awaitable(asyncio.sleep(1))
+    await a
 
 asyncio.run(main())
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ testpaths = [
 module = "asynkit.*"
 strict = true
 
+[[tool.mypy.overrides]]
+module = "asynkit.eventloop"
+warn_unused_ignores=false
+
 [tool.coverage.report]
 exclude_lines = [
   "pragma: no cover",

--- a/src/asynkit/eventloop.py
+++ b/src/asynkit/eventloop.py
@@ -140,15 +140,14 @@ if not TYPE_CHECKING and hasattr(asyncio, "ProactorEventLoop"):  # pragma: no co
 if sys.platform == "win32" and globals().get(
     "SchedulingProactorEventLoop"
 ):  # pragma: no coverage
-
-    DefaultSchedulingEventLoop = globals().get("SchedulingProactorEventLoop")
+    DefaultSchedulingEventLoop = SchedulingProactorEventLoop  # type: ignore
 else:  # pragma: no coverage
     DefaultSchedulingEventLoop = SchedulingSelectorEventLoop
 
 
 class SchedulingEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     def new_event_loop(self) -> AbstractEventLoop:
-        return DefaultSchedulingEventLoop()
+        return DefaultSchedulingEventLoop()  # type: ignore
 
 
 @contextlib.contextmanager

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -561,3 +561,25 @@ async def test_coro_is_suspended():
 
     with pytest.raises(TypeError):
         asynkit.coroutine.coro_is_suspended("str")
+
+
+async def test_coro_iter():
+    async def coroutine1(val):
+        await sleep(0)
+        return "foo" + val
+
+    async def coroutine2(val):
+        await sleep(0)
+        raise RuntimeError("foo" + val)
+
+    class Awaiter:
+        def __init__(self, coro):
+            self.coro = coro
+
+        def __await__(self):
+            return asynkit.coro_iter(self.coro)
+
+    assert await Awaiter(coroutine1("bar")) == "foobar"
+    with pytest.raises(RuntimeError) as err:
+        await Awaiter(coroutine2("bar"))
+    assert err.value.args[0] == "foobar"


### PR DESCRIPTION
`coro_iter()` returns a generator which implements the `await` protocol.
This allows it to be returned from an `object.__await__()` method, but this method must return an iterator and not
a coroutine.  
This makes it simpler to make objects awaitable by allowing coroutines to feed the `__await__()` method.