### PR TITLE
Add Monitor.awaitable() method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+* Add `Monitor.awaitable()` method and `MonitorAwaitable` class
 * Add the coro_iter() helper
 * Move Task creation out of the `CoroStart` class and into `coro_eager()` helper.
 * Add Monitor class and GeneratorObject

--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ done
 ```
 
 The caller can also pass in data to the coroutine via the `Monitor.aawait(coro, data:None)` method and
-it will become the result of the `Monitor.oob()` call inside the monitor.   `Monitor.athrow()` can be
-used to raise an exception inside the coroutine.
+it will become the result of the `Monitor.oob()` call in the coroutine.
+`Monitor.athrow()` can be used to raise an exception inside the coroutine.
+Neither data nor an exception cannot be sent the first time the coroutine is awaited, 
+only as a response to a previous `OOBData` exception.
 
-If no data needs to be sent, an _awaitable_ object can be generated to simplify
+If no data is to be sent (the common case), an _awaitable_ object can be generated to simplify
 the syntax:
 
 ```python
@@ -220,6 +222,12 @@ while True:
         return await a
     except OOBData as oob:
         handle_oob(oob.data)
+```
+The returned awaitable is a `MonitorAwaitable` instance, and it can also be created
+directly:
+
+```python
+a = MonitorAwaitable(m, coro(m))
 ```
 
 A Monitor can be used when a coroutine wants to suspend itself, maybe waiting for some extenal

--- a/src/asynkit/__init__.py
+++ b/src/asynkit/__init__.py
@@ -1,8 +1,9 @@
 from .coroutine import *
 from .eventloop import *
 from .monitor import (
-    Monitor,
     GeneratorObject,
     GeneratorObjectIterator,
+    Monitor,
+    MonitorAwaitable,
     OOBData,
 )

--- a/src/asynkit/monitor.py
+++ b/src/asynkit/monitor.py
@@ -65,10 +65,10 @@ class Monitor(Generic[T]):
         Await a coroutine after an initial "send" call which is either
         `send()` or `throw()`, while handling the OOB data protocol.
         """
-        return (yield from self._asend_raw(coro, callable, args))
+        return (yield from self._asend_iter(coro, callable, args))
 
     # A straight generator, suitable for __await__ magic methods.
-    def _asend_raw(
+    def _asend_iter(
         self,
         coro: Coroutine[Any, Any, T],
         callable: Callable[..., Any],
@@ -183,7 +183,7 @@ class MonitorAwaitable(Generic[T]):
         self.coro = coro
 
     def __await__(self)-> Generator[Any, Any, T] :
-        return self.monitor._asend_raw(self.coro, self.coro.send, (None,))
+        return self.monitor._asend_iter(self.coro, self.coro.send, (None,))
         
 
 class GeneratorObject(Generic[T, V]):

--- a/src/asynkit/monitor.py
+++ b/src/asynkit/monitor.py
@@ -125,9 +125,12 @@ class Monitor(Generic[T]):
     def awaitable(
         self,
         coro: Coroutine[Any, Any, T],
-        ) -> Awaitable[T]:
+    ) -> Awaitable[T]:
+        """
+        Return a `MontiorAwaitable` object which can be awaited instead
+        of explicitly awaiting `Montiro.aawait()`
+        """
         return MonitorAwaitable(self, coro)
-
 
     @overload
     async def athrow(
@@ -178,13 +181,18 @@ class Monitor(Generic[T]):
 
 
 class MonitorAwaitable(Generic[T]):
+    """
+    An awaitable helper class which can be awaited to invoke a
+    `await Monitior.aawait(coroutine)`
+    """
+
     def __init__(self, monitor: Monitor[T], coro: Coroutine[Any, Any, T]) -> None:
         self.monitor = monitor
         self.coro = coro
 
-    def __await__(self)-> Generator[Any, Any, T] :
+    def __await__(self) -> Generator[Any, Any, T]:
         return self.monitor._asend_iter(self.coro, self.coro.send, (None,))
-        
+
 
 class GeneratorObject(Generic[T, V]):
     __slots__ = ["monitor"]

--- a/src/asynkit/monitor.py
+++ b/src/asynkit/monitor.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     AsyncIterator,
     AsyncGenerator,
+    Awaitable,
     Callable,
     Coroutine,
     Generator,
@@ -64,6 +65,15 @@ class Monitor(Generic[T]):
         Await a coroutine after an initial "send" call which is either
         `send()` or `throw()`, while handling the OOB data protocol.
         """
+        return (yield from self._asend_raw(coro, callable, args))
+
+    # A straight generator, suitable for __await__ magic methods.
+    def _asend_raw(
+        self,
+        coro: Coroutine[Any, Any, T],
+        callable: Callable[..., Any],
+        args: Tuple[Any, ...],
+    ) -> Generator[Any, Any, T]:
         if self.state != 0:
             raise RuntimeError("Monitor cannot be re-entered")
         self.state = 1
@@ -98,7 +108,6 @@ class Monitor(Generic[T]):
         finally:
             self.state = 0
 
-    @types.coroutine
     async def aawait(
         self,
         coro: Coroutine[Any, Any, T],
@@ -112,6 +121,13 @@ class Monitor(Generic[T]):
         to pass data as the return value for the `oob()` call for a subsequent call.
         """
         return await self._asend(coro, coro.send, (data,))
+
+    def awaitable(
+        self,
+        coro: Coroutine[Any, Any, T],
+        ) -> Awaitable[T]:
+        return MonitorAwaitable(self, coro)
+
 
     @overload
     async def athrow(
@@ -160,6 +176,15 @@ class Monitor(Generic[T]):
         self.state = -1
         return (yield data)
 
+
+class MonitorAwaitable(Generic[T]):
+    def __init__(self, monitor: Monitor[T], coro: Coroutine[Any, Any, T]) -> None:
+        self.monitor = monitor
+        self.coro = coro
+
+    def __await__(self)-> Generator[Any, Any, T] :
+        return self.monitor._asend_raw(self.coro, self.coro.send, (None,))
+        
 
 class GeneratorObject(Generic[T, V]):
     __slots__ = ["monitor"]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -4,7 +4,7 @@ from anyio import sleep
 
 import pytest
 
-from asynkit import GeneratorObject, Monitor, OOBData
+from asynkit import GeneratorObject, Monitor, OOBData, MonitorAwaitable
 
 pytestmark = pytest.mark.anyio
 # Most tests here are just testing coroutine behaviour.
@@ -52,6 +52,17 @@ class TestMonitor:
 
         m = Monitor()
         a = m.awaitable(helper(m))
+        with pytest.raises(OOBData) as data:
+            await a
+        assert data.value.data == "foo"
+        with pytest.raises(OOBData) as data:
+            await a
+        assert data.value.data == "Nonefoo"
+        back = await a
+        assert back == "Nonefoo"
+
+        # create the awaitable directly
+        a = MonitorAwaitable(m, helper(m))
         with pytest.raises(OOBData) as data:
             await a
         assert data.value.data == "foo"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -38,6 +38,30 @@ class TestMonitor:
         back = await m.aawait(c, "how")
         assert back == "howfoo"
 
+    async def test_monitor_awaitable(self):
+        """
+        Test basic monitor awaitable object
+        """
+
+        async def helper(m):
+            back = await m.oob("foo")
+            await sleep(0)
+            back = await m.oob(str(back) + "foo")
+            await sleep(0)
+            return str(back) + "foo"
+
+        m = Monitor()
+        c = helper(m)
+        a = m.awaitable(c)
+        with pytest.raises(OOBData) as data:
+            await a
+        assert data.value.data == "foo"
+        with pytest.raises(OOBData) as data:
+            await a
+        assert data.value.data == "Nonefoo"
+        back = await a
+        assert back == "Nonefoo"
+
     async def test_throw(self):
         """
         Assert that throwing an error into the coroutine after the first OOB

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -51,8 +51,7 @@ class TestMonitor:
             return str(back) + "foo"
 
         m = Monitor()
-        c = helper(m)
-        a = m.awaitable(c)
+        a = m.awaitable(helper(m))
         with pytest.raises(OOBData) as data:
             await a
         assert data.value.data == "foo"


### PR DESCRIPTION
the `awaitable()` method creates a `MonitorAwaitable` instance with an `__await__` method, which can be used to repeatedly await, without having to invoke the `aawait()` method explicitly every time.