### PR TITLE
add CoroStart.as_awaitable()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+* Add `CoroStart.as_awaitable()` method
 * Add `Monitor.awaitable()` method and `MonitorAwaitable` class
 * Add the coro_iter() helper
 * Move Task creation out of the `CoroStart` class and into `coro_eager()` helper.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Similarly to a `Future`, it has these methods:
 - `as_future()` - If `done()`, returns a `Future` holding its result, otherwise, a `RuntimeError`
   is raised. This is suitable for using with
   `asyncio.gather()` to avoid wrapping the result of an already completed coroutine into a `Task`.
+- `as_awaitable()` - If `done()`, returns `as_future()`, else returns `as_coroutine()`.
+  This is a convenience method for use with functions such as `asyncio.gather()` to avoid
+  it creating a `Task` object when `CoroStart.done() is True`.
 
 CoroStart can be provided with a `contextvars.Context` object, in which case the coroutine will be run using that
 context.

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -267,6 +267,19 @@ class CoroStart(Awaitable[T_co]):
             future.set_exception(exc)
         return future
 
+    def as_awaitable(self) -> Awaitable[T_co]:
+        """
+        If `done()`, return `as_future()`, else `as_coroutine()`.
+        This is a convenience function for use when the instance
+        is to be passed directly to methods such as `asyncio.gather()`.
+        In such cases, we want to avoid a `done()` instance to cause
+        a `Task` to be created just to retrieve the result.
+        """
+        if self.done():
+            return self.as_future()
+        else:
+            return self.as_coroutine()
+
 
 async def coro_await(coro: CoroLike[T], *, context: Optional[Context] = None) -> T:
     """

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -265,27 +265,29 @@ class TestCoroStart:
         coro, expect = self.get_coro1(block)
         log = []
         cs = asynkit.CoroStart(coro(log))
+        log.append("a")
         if block:
             with pytest.raises(RuntimeError) as err:
                 fut = cs.as_future()
             assert err.match(r"not done")
-            await cs
+            assert await cs == expect
         else:
             fut = cs.as_future()
             assert isinstance(fut, asyncio.Future)
-            await fut
+            assert await fut == expect
 
     @pytest.mark.parametrize("anyio_backend", ["asyncio"])
     async def test_as_awaitable(self, block, anyio_backend):
         coro, expect = self.get_coro1(block)
         log = []
         cs = asynkit.CoroStart(coro(log))
+        log.append("a")
         awaitable = cs.as_awaitable()
         if block:
             assert inspect.iscoroutine(awaitable)
         else:
             assert isinstance(awaitable, asyncio.Future)
-        await awaitable
+        assert await awaitable == expect
 
     async def test_result(self, block):
         coro, _ = self.get_coro1(block)

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -269,9 +269,23 @@ class TestCoroStart:
             with pytest.raises(RuntimeError) as err:
                 fut = cs.as_future()
             assert err.match(r"not done")
+            await cs
         else:
             fut = cs.as_future()
             assert isinstance(fut, asyncio.Future)
+            await fut
+
+    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    async def test_as_awaitable(self, block, anyio_backend):
+        coro, expect = self.get_coro1(block)
+        log = []
+        cs = asynkit.CoroStart(coro(log))
+        awaitable = cs.as_awaitable()
+        if block:
+            assert inspect.iscoroutine(awaitable)
+        else:
+            assert isinstance(awaitable, asyncio.Future)
+        await awaitable
 
     async def test_result(self, block):
         coro, _ = self.get_coro1(block)


### PR DESCRIPTION
as_awaitable() returns a `Future` object if the `CoroStart` is `done()` so that functions such as `asyncio.gather()` won't create a `Task` object to await it.