### PR TITLE
Fix Python 3.14 loop policy deprecation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Python 3.14 event loop policy warnings**: Suppressed `asyncio`'s own event loop policy deprecation warnings when asynkit internally touches policy APIs for compatibility
+  - `import asynkit` no longer emits policy deprecation warnings on Python 3.14+
+  - `SchedulingEventLoopPolicy`, `PriorityEventLoopPolicy`, and `event_loop_policy()` remain available for clients still using loop policies
+  - asynkit now emits its own deprecation warning when those policy extension APIs are used on Python 3.14+, pointing users toward `scheduling_loop_factory()` with `asyncio.run()` or `asyncio.Runner`
+
 ## [0.18.0] - 2025-12-29
 
 ### Major Changes

--- a/src/asynkit/experimental/priority.py
+++ b/src/asynkit/experimental/priority.py
@@ -25,6 +25,7 @@ from asynkit.compat import (
     ReferenceTypeTaskAny,
 )
 from asynkit.loop.default import task_from_handle
+from asynkit.loop.eventloop import _DefaultEventLoopPolicy, _warn_policy_deprecated
 from asynkit.loop.schedulingloop import AbstractSchedulingLoop
 from asynkit.loop.types import TaskAny
 from asynkit.scheduling import task_is_runnable
@@ -724,6 +725,10 @@ if hasattr(asyncio, "ProactorEventLoop"):  # pragma: no coverage
     __all__.append("PriorityProactorEventLoop")
 
 
-class PriorityEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class PriorityEventLoopPolicy(_DefaultEventLoopPolicy):
+    def __init__(self) -> None:
+        _warn_policy_deprecated("PriorityEventLoopPolicy")
+        super().__init__()
+
     def new_event_loop(self) -> asyncio.AbstractEventLoop:
         return DefaultPriorityEventLoop()  # type: ignore

--- a/src/asynkit/loop/eventloop.py
+++ b/src/asynkit/loop/eventloop.py
@@ -72,8 +72,7 @@ def _warn_policy_deprecated(name: str, stacklevel: int = 2) -> None:
 
 
 if TYPE_CHECKING:
-    from asyncio import AbstractEventLoopPolicy
-
+    AbstractEventLoopPolicy = asyncio.AbstractEventLoopPolicy
     _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 else:
     with _ignore_asyncio_policy_deprecation():

--- a/src/asynkit/loop/eventloop.py
+++ b/src/asynkit/loop/eventloop.py
@@ -42,12 +42,24 @@ else:
 
 T = TypeVar("T")
 
+_POLICY_NAMES = (
+    r"(asyncio\.)?(AbstractEventLoopPolicy|DefaultEventLoopPolicy|"
+    r"get_event_loop_policy|set_event_loop_policy)"
+)
+_ASYNCIO_POLICY_DEPRECATION = (
+    rf".*({_POLICY_NAMES}.*deprecated|deprecated.*{_POLICY_NAMES})"
+)
+
 
 @contextlib.contextmanager
 def _ignore_asyncio_policy_deprecation() -> Generator[None, Any, None]:
     with warnings.catch_warnings():
         # this context only wraps our own deprecated policy API calls
-        warnings.simplefilter("ignore", DeprecationWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message=_ASYNCIO_POLICY_DEPRECATION,
+            category=DeprecationWarning,
+        )
         yield
 
 

--- a/src/asynkit/loop/eventloop.py
+++ b/src/asynkit/loop/eventloop.py
@@ -4,7 +4,8 @@ import asyncio
 import asyncio.base_events
 import contextlib
 import sys
-from asyncio import AbstractEventLoop, AbstractEventLoopPolicy, Future, Handle, Task
+import warnings
+from asyncio import AbstractEventLoop, Future, Handle, Task
 from collections import deque
 from collections.abc import Callable, Generator, Iterable
 from contextvars import Context
@@ -40,6 +41,44 @@ else:
     FutureAny = Future
 
 T = TypeVar("T")
+
+_ASYNCIO_POLICY_DEPRECATION = (
+    r"'asyncio\.(AbstractEventLoopPolicy|DefaultEventLoopPolicy|"
+    r"get_event_loop_policy|set_event_loop_policy)' is deprecated"
+)
+
+
+@contextlib.contextmanager
+def _ignore_asyncio_policy_deprecation() -> Generator[None, Any, None]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=_ASYNCIO_POLICY_DEPRECATION,
+            category=DeprecationWarning,
+        )
+        yield
+
+
+def _warn_policy_deprecated(name: str, stacklevel: int = 2) -> None:
+    if sys.version_info >= (3, 14):
+        warnings.warn(
+            f"{name} uses asyncio event loop policies, which are deprecated "
+            "as of Python 3.14 and will be removed in Python 3.16. "
+            "Use scheduling_loop_factory() with asyncio.run() or "
+            "asyncio.Runner instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+
+
+if TYPE_CHECKING:
+    from asyncio import AbstractEventLoopPolicy
+
+    _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
+else:
+    with _ignore_asyncio_policy_deprecation():
+        AbstractEventLoopPolicy = asyncio.AbstractEventLoopPolicy
+        _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
 
 class HasReadyQueue(Protocol):
@@ -142,7 +181,7 @@ def scheduling_loop_factory() -> AbstractEventLoop:
     return DefaultSchedulingEventLoop()  # type: ignore
 
 
-class SchedulingEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class SchedulingEventLoopPolicy(_DefaultEventLoopPolicy):
     """
     Event loop policy that creates scheduling event loops.
 
@@ -154,6 +193,10 @@ class SchedulingEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     code that hasn't migrated away from the policy system.
     """
 
+    def __init__(self) -> None:
+        _warn_policy_deprecated("SchedulingEventLoopPolicy")
+        super().__init__()
+
     def new_event_loop(self) -> AbstractEventLoop:
         return scheduling_loop_factory()
 
@@ -162,10 +205,15 @@ class SchedulingEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
 def event_loop_policy(
     policy: AbstractEventLoopPolicy | None = None,
 ) -> Generator[AbstractEventLoopPolicy, Any, None]:
-    policy = policy or SchedulingEventLoopPolicy()
-    previous = asyncio.get_event_loop_policy()
-    asyncio.set_event_loop_policy(policy)
+    if policy is None:
+        policy = SchedulingEventLoopPolicy()
+    else:
+        _warn_policy_deprecated("event_loop_policy()")
+    with _ignore_asyncio_policy_deprecation():
+        previous = asyncio.get_event_loop_policy()
+        asyncio.set_event_loop_policy(policy)
     try:
         yield policy
     finally:
-        asyncio.set_event_loop_policy(previous)
+        with _ignore_asyncio_policy_deprecation():
+            asyncio.set_event_loop_policy(previous)

--- a/src/asynkit/loop/eventloop.py
+++ b/src/asynkit/loop/eventloop.py
@@ -42,24 +42,16 @@ else:
 
 T = TypeVar("T")
 
-_ASYNCIO_POLICY_DEPRECATION = (
-    r"'asyncio\.(AbstractEventLoopPolicy|DefaultEventLoopPolicy|"
-    r"get_event_loop_policy|set_event_loop_policy)' is deprecated"
-)
-
 
 @contextlib.contextmanager
 def _ignore_asyncio_policy_deprecation() -> Generator[None, Any, None]:
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=_ASYNCIO_POLICY_DEPRECATION,
-            category=DeprecationWarning,
-        )
+        # this context only wraps our own deprecated policy API calls
+        warnings.simplefilter("ignore", DeprecationWarning)
         yield
 
 
-def _warn_policy_deprecated(name: str, stacklevel: int = 2) -> None:
+def _warn_policy_deprecated(name: str, stacklevel: int = 3) -> None:
     if sys.version_info >= (3, 14):
         warnings.warn(
             f"{name} uses asyncio event loop policies, which are deprecated "

--- a/src/asynkit/loop/eventloop.py
+++ b/src/asynkit/loop/eventloop.py
@@ -209,9 +209,16 @@ def event_loop_policy(
     policy: AbstractEventLoopPolicy | None = None,
 ) -> Generator[AbstractEventLoopPolicy, Any, None]:
     if policy is None:
-        policy = SchedulingEventLoopPolicy()
+        _warn_policy_deprecated("event_loop_policy()", stacklevel=4)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="SchedulingEventLoopPolicy uses asyncio event loop policies",
+                category=DeprecationWarning,
+            )
+            policy = SchedulingEventLoopPolicy()
     else:
-        _warn_policy_deprecated("event_loop_policy()")
+        _warn_policy_deprecated("event_loop_policy()", stacklevel=4)
     with _ignore_asyncio_policy_deprecation():
         previous = asyncio.get_event_loop_policy()
         asyncio.set_event_loop_policy(policy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import warnings
 
 import pytest
 
@@ -92,7 +93,16 @@ def scheduling_loop_type(request):
 
 
 # loop policy for pytest-anyio plugin
-class SchedulingEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
+        category=DeprecationWarning,
+    )
+    _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
+
+
+class SchedulingEventLoopPolicy(_DefaultEventLoopPolicy):
     def __init__(self, request, eager_tasks=False):
         super().__init__()
         self.request = request

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import asyncio
 import sys
-import warnings
 
 import pytest
 
 import asynkit
 import asynkit.coroutine as coroutine_module
+from asynkit.loop.eventloop import _ignore_asyncio_policy_deprecation
 
 DefaultLoop = asynkit.DefaultSchedulingEventLoop
 SelectorLoop = asynkit.SchedulingSelectorEventLoop
@@ -93,12 +93,7 @@ def scheduling_loop_type(request):
 
 
 # loop policy for pytest-anyio plugin
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
-        category=DeprecationWarning,
-    )
+with _ignore_asyncio_policy_deprecation():
     _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
 

--- a/tests/experimental/test_priority.py
+++ b/tests/experimental/test_priority.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import warnings
 from unittest.mock import Mock
 
 import pytest
@@ -16,10 +17,18 @@ from ..conftest import make_loop_factory
 
 pytestmark = pytest.mark.anyio
 
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
+        category=DeprecationWarning,
+    )
+    _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
+
 
 @pytest.fixture
 def anyio_backend():
-    policy = asyncio.DefaultEventLoopPolicy()
+    policy = _DefaultEventLoopPolicy()
     return "asyncio", {"loop_factory": make_loop_factory(policy)}
 
 
@@ -618,7 +627,7 @@ class TestPosPriorityQueue:
 
 
 # loop policy for pytest-anyio plugin
-class PriorityEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+class PriorityEventLoopPolicy(_DefaultEventLoopPolicy):
     def __init__(self, request):
         super().__init__()
         self.request = request

--- a/tests/experimental/test_priority.py
+++ b/tests/experimental/test_priority.py
@@ -1,6 +1,5 @@
 import asyncio
 import random
-import warnings
 from unittest.mock import Mock
 
 import pytest
@@ -12,17 +11,13 @@ from asynkit.experimental.priority import (
     PriorityLock,
     PriorityTask,
 )
+from asynkit.loop.eventloop import _ignore_asyncio_policy_deprecation
 
 from ..conftest import make_loop_factory
 
 pytestmark = pytest.mark.anyio
 
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
-        category=DeprecationWarning,
-    )
+with _ignore_asyncio_policy_deprecation():
     _DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
 

--- a/tests/test_eager_task_factory.py
+++ b/tests/test_eager_task_factory.py
@@ -1,11 +1,11 @@
 """Tests for eager_task_factory functionality."""
 
 import asyncio
-import warnings
 
 import pytest
 
 import asynkit
+from asynkit.loop.eventloop import _ignore_asyncio_policy_deprecation
 
 
 @pytest.fixture
@@ -35,13 +35,7 @@ def asyncio_run_eager():
     eager task factory on new loops. This tests the modern asyncio.run()
     pattern with eager execution.
     """
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"'asyncio\.(get_event_loop_policy|set_event_loop_policy)' "
-            "is deprecated",
-            category=DeprecationWarning,
-        )
+    with _ignore_asyncio_policy_deprecation():
         original_policy = asyncio.get_event_loop_policy()
 
     # Create a custom policy that installs eager task factory
@@ -52,22 +46,12 @@ def asyncio_run_eager():
             return loop
 
     policy = EagerPolicy()
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"'asyncio\.set_event_loop_policy' is deprecated",
-            category=DeprecationWarning,
-        )
+    with _ignore_asyncio_policy_deprecation():
         asyncio.set_event_loop_policy(policy)
     try:
         yield asyncio.run
     finally:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"'asyncio\.set_event_loop_policy' is deprecated",
-                category=DeprecationWarning,
-            )
+        with _ignore_asyncio_policy_deprecation():
             asyncio.set_event_loop_policy(original_policy)
 
 

--- a/tests/test_eager_task_factory.py
+++ b/tests/test_eager_task_factory.py
@@ -1,6 +1,7 @@
 """Tests for eager_task_factory functionality."""
 
 import asyncio
+import warnings
 
 import pytest
 
@@ -34,7 +35,14 @@ def asyncio_run_eager():
     eager task factory on new loops. This tests the modern asyncio.run()
     pattern with eager execution.
     """
-    original_policy = asyncio.get_event_loop_policy()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"'asyncio\.(get_event_loop_policy|set_event_loop_policy)' "
+            "is deprecated",
+            category=DeprecationWarning,
+        )
+        original_policy = asyncio.get_event_loop_policy()
 
     # Create a custom policy that installs eager task factory
     class EagerPolicy(type(original_policy)):
@@ -44,11 +52,23 @@ def asyncio_run_eager():
             return loop
 
     policy = EagerPolicy()
-    asyncio.set_event_loop_policy(policy)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"'asyncio\.set_event_loop_policy' is deprecated",
+            category=DeprecationWarning,
+        )
+        asyncio.set_event_loop_policy(policy)
     try:
         yield asyncio.run
     finally:
-        asyncio.set_event_loop_policy(original_policy)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"'asyncio\.set_event_loop_policy' is deprecated",
+                category=DeprecationWarning,
+            )
+            asyncio.set_event_loop_policy(original_policy)
 
 
 class TestEagerFactory:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2,7 +2,6 @@ import asyncio
 import subprocess
 import sys
 import warnings
-from asyncio import DefaultEventLoopPolicy
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +23,14 @@ from .conftest import SchedulingEventLoopPolicy, make_loop_factory
 from .experimental.test_priority import PriorityEventLoopPolicy
 
 pytestmark = pytest.mark.anyio
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
+        category=DeprecationWarning,
+    )
+    DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
 
 @pytest.fixture(params=["regular", "custom", "priority"])

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -539,13 +539,19 @@ class TestTaskIsBlocked:
 
 
 def test_event_loop_policy_context():
-    with asynkit.event_loop_policy() as a:
-        assert isinstance(a, asynkit.SchedulingEventLoopPolicy)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="SchedulingEventLoopPolicy uses asyncio event loop policies",
+            category=DeprecationWarning,
+        )
+        with asynkit.event_loop_policy() as a:
+            assert isinstance(a, asynkit.SchedulingEventLoopPolicy)
 
-        async def foo():
-            assert isinstance(asyncio.get_running_loop(), asynkit.SchedulingMixin)
+            async def foo():
+                assert isinstance(asyncio.get_running_loop(), asynkit.SchedulingMixin)
 
-        asyncio.run(foo())
+            asyncio.run(foo())
 
 
 def test_import_asynkit_does_not_warn_about_asyncio_policies():

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,5 +1,7 @@
 import asyncio
+import subprocess
 import sys
+import warnings
 from asyncio import DefaultEventLoopPolicy
 from unittest.mock import patch
 
@@ -537,6 +539,31 @@ def test_event_loop_policy_context():
             assert isinstance(asyncio.get_running_loop(), asynkit.SchedulingMixin)
 
         asyncio.run(foo())
+
+
+def test_import_asynkit_does_not_warn_about_asyncio_policies():
+    subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", "import asynkit"],
+        check=True,
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="asyncio event loop policy deprecation starts in Python 3.14",
+)
+def test_asynkit_policy_warning_replaces_asyncio_policy_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with asynkit.event_loop_policy() as policy:
+            assert isinstance(policy, asynkit.SchedulingEventLoopPolicy)
+
+    messages = [str(item.message) for item in caught]
+    assert any(
+        message.startswith("SchedulingEventLoopPolicy uses asyncio event loop policies")
+        for message in messages
+    )
+    assert not any(message.startswith("'asyncio.") for message in messages)
 
 
 @pytest.mark.skipif(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import asynkit
+from asynkit.loop.eventloop import _ignore_asyncio_policy_deprecation
 from asynkit.loop.extensions import (
     call_pos,
     get_ready_queue,
@@ -24,12 +25,7 @@ from .experimental.test_priority import PriorityEventLoopPolicy
 
 pytestmark = pytest.mark.anyio
 
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        message=r"'asyncio\.DefaultEventLoopPolicy' is deprecated",
-        category=DeprecationWarning,
-    )
+with _ignore_asyncio_policy_deprecation():
     DefaultEventLoopPolicy = asyncio.DefaultEventLoopPolicy
 
 
@@ -559,6 +555,25 @@ def test_import_asynkit_does_not_warn_about_asyncio_policies():
         [sys.executable, "-W", "error::DeprecationWarning", "-c", "import asynkit"],
         check=True,
     )
+
+
+def test_policy_warning_filter_keeps_unrelated_deprecations():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with _ignore_asyncio_policy_deprecation():
+            asyncio.DefaultEventLoopPolicy
+            warnings.warn(
+                "The DefaultEventLoopPolicy class is deprecated",
+                DeprecationWarning,
+            )
+            warnings.warn(
+                "The set_event_loop_policy() function is deprecated",
+                DeprecationWarning,
+            )
+            warnings.warn("some other thing is deprecated", DeprecationWarning)
+
+    messages = [str(item.message) for item in caught]
+    assert messages == ["some other thing is deprecated"]
 
 
 @pytest.mark.skipif(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,7 +1,9 @@
 import asyncio
+import os
 import subprocess
 import sys
 import warnings
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -538,7 +540,7 @@ def test_event_loop_policy_context():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="SchedulingEventLoopPolicy uses asyncio event loop policies",
+            message=r"event_loop_policy\(\) uses asyncio event loop policies",
             category=DeprecationWarning,
         )
         with asynkit.event_loop_policy() as a:
@@ -551,10 +553,35 @@ def test_event_loop_policy_context():
 
 
 def test_import_asynkit_does_not_warn_about_asyncio_policies():
+    env = os.environ.copy()
+    src_path = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in (src_path, env.get("PYTHONPATH", "")) if path
+    )
     subprocess.run(
         [sys.executable, "-W", "error::DeprecationWarning", "-c", "import asynkit"],
         check=True,
+        env=env,
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="asyncio event loop policy deprecation starts in Python 3.14",
+)
+def test_asynkit_policy_warnings_point_to_user_code():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        asynkit.SchedulingEventLoopPolicy()
+
+    assert caught[0].filename == __file__
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        with asynkit.event_loop_policy():
+            pass
+
+    assert caught[0].filename == __file__
 
 
 def test_policy_warning_filter_keeps_unrelated_deprecations():
@@ -588,7 +615,7 @@ def test_asynkit_policy_warning_replaces_asyncio_policy_warning():
 
     messages = [str(item.message) for item in caught]
     assert any(
-        message.startswith("SchedulingEventLoopPolicy uses asyncio event loop policies")
+        message.startswith("event_loop_policy() uses asyncio event loop policies")
         for message in messages
     )
     asynkit_warning_prefixes = (

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -576,7 +576,22 @@ def test_asynkit_policy_warning_replaces_asyncio_policy_warning():
         message.startswith("SchedulingEventLoopPolicy uses asyncio event loop policies")
         for message in messages
     )
-    assert not any(message.startswith("'asyncio.") for message in messages)
+    asynkit_warning_prefixes = (
+        "SchedulingEventLoopPolicy uses asyncio event loop policies",
+        "PriorityEventLoopPolicy uses asyncio event loop policies",
+        "event_loop_policy() uses asyncio event loop policies",
+    )
+
+    def is_asyncio_policy_deprecation(message: str) -> bool:
+        normalized = message.lower()
+        return (
+            not message.startswith(asynkit_warning_prefixes)
+            and "asyncio." in normalized
+            and "policy" in normalized
+            and "deprecated" in normalized
+        )
+
+    assert not any(is_asyncio_policy_deprecation(message) for message in messages)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- suppress asyncio's own event loop policy deprecation warnings when asynkit internally resolves or restores policy APIs for compatibility
- emit asynkit-owned deprecation warnings when users instantiate or use asynkit policy extensions on Python 3.14+
- add tests covering clean imports with `DeprecationWarning` promoted to errors and the replacement warning behavior

## Validation

- `python -W error::DeprecationWarning -c "import asynkit; import asynkit.experimental.priority"`
- `pytest -q`
- `mypy -p asynkit -p tests -p examples`
- `ruff check ...`