### PR TITLE
Add experimental live context helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Experimental live context helper**: Added `get_current_context()` for CPython builds with the asynkit C extension
+  - Returns the currently active `contextvars.Context` object instead of a copy
+  - Raises `NotImplementedError` when the C extension helper is unavailable
+  - Allows advanced `CoroStart` users to explicitly share one context across eager start and remote continuation
+  - Documented the intentional break from normal `contextvars` isolation and the requirement that callers wait while shared-context remote execution runs
+
 ## [0.17.7] - 2026-06-23
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -507,8 +507,10 @@ This is an experimental escape hatch. It intentionally breaks normal context iso
 now mutate the same `Context` object. Use it only when you can guarantee that the caller waits while the remote execution
 is using the shared context. The same context must not be actively entered in two places at once.
 
-One use for this is to start a coroutine in the current context, then hand the blocking continuation to another executor,
-such as a worker thread:
+One use for this is synchronous code that receives an async operation and wants to run the non-blocking prefix directly.
+If the coroutine blocks, it has already blocked on the current thread's event loop. The continuation must therefore run
+on that same loop, for example by creating a Task there while the synchronous caller waits using polling, stack switching,
+or some other mechanism that lets the loop keep making progress:
 
 ```python
 import asyncio
@@ -522,37 +524,50 @@ var = contextvars.ContextVar("var")
 async def work():
     var.set("started")
 
-    # after this point, the coroutine can be continued somewhere else
+    # after this point, the coroutine is blocked on the current event loop
     await asyncio.sleep(0)
 
     var.set("finished")
     return "done"
 
 
-async def main():
-    var.set("caller")
+def wait_for_task(task):
+    ...  # poll or switch stacks until `task` is done, while letting the loop run
+    return task.result()
+
+
+def run_from_blocking_code(coro, wait_for_task):
+    loop = asyncio.get_running_loop()
     context = asynkit.get_current_context()
 
     # `context` is for the continuation. The initial `start()` runs in the
     # already-active caller context, so do not pass `context` to `start()`.
-    start = asynkit.CoroStart(work(), context=context, autostart=False)
+    start = asynkit.CoroStart(coro, context=context, autostart=False)
     if start.start():
         return start.result()
 
     assert var.get() == "started"
 
-    # The caller waits while the worker thread continues the coroutine.
+    # Continue on the same loop the coroutine blocked on. `wait_for_task()`
+    # might poll, switch stacks, or otherwise wait while letting `loop` run.
     # CoroStart itself enters `context` while driving the continuation.
-    result = await asyncio.to_thread(asyncio.run, start.as_coroutine())
+    task = loop.create_task(start.as_coroutine())
+    result = wait_for_task(task)
 
     assert result == "done"
     assert var.get() == "finished"
+
+
+async def main():
+    var.set("caller")
+    return run_from_blocking_code(work(), wait_for_task)
 ```
 
 Needless to say, this is a sharp tool. Do not wrap `start.as_coroutine()` in `context.run()` and do not also pass the
 same `context` to `asyncio.create_task(..., context=context)`, because `CoroStart` already uses that context when it
-resumes the coroutine. If you only need ordinary task context propagation, use `copy_context()` or the normal eager task
-helpers instead.
+resumes the coroutine. Also do not move a blocked `CoroStart` to a different event loop with `asyncio.run()` or a worker
+thread: the coroutine may already be waiting on an asyncio object owned by the original loop. If you only need ordinary
+task context propagation, use `copy_context()` or the normal eager task helpers instead.
 
 ### Context helper
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,63 @@ async with aclosing(CoroStart(foo())) as coro:
 CoroStart can be provided with a `contextvars.Context` object, in which case the coroutine will be run using that
 context.
 
+#### Experimental: sharing the current context
+
+Python intentionally does not expose the currently active `contextvars.Context` object. It only lets you copy it with
+`contextvars.copy_context()`. On CPython, and only when the asynkit C extension is available, `get_current_context()`
+returns that live current context object instead. If the live context cannot be retrieved, it raises `NotImplementedError`.
+
+This is an experimental escape hatch. It intentionally breaks normal context isolation, because two pieces of code can
+now mutate the same `Context` object. Use it only when you can guarantee that the caller waits while the remote execution
+is using the shared context. The same context must not be actively entered in two places at once.
+
+One use for this is to start a coroutine in the current context, then hand the blocking continuation to another executor,
+such as a worker thread:
+
+```python
+import asyncio
+import contextvars
+
+import asynkit
+
+var = contextvars.ContextVar("var")
+
+
+async def work():
+    var.set("started")
+
+    # after this point, the coroutine can be continued somewhere else
+    await asyncio.sleep(0)
+
+    var.set("finished")
+    return "done"
+
+
+async def main():
+    var.set("caller")
+    context = asynkit.get_current_context()
+
+    # `context` is for the continuation. The initial `start()` runs in the
+    # already-active caller context, so do not pass `context` to `start()`.
+    start = asynkit.CoroStart(work(), context=context, autostart=False)
+    if start.start():
+        return start.result()
+
+    assert var.get() == "started"
+
+    # The caller waits while the worker thread continues the coroutine.
+    # CoroStart itself enters `context` while driving the continuation.
+    result = await asyncio.to_thread(asyncio.run, start.as_coroutine())
+
+    assert result == "done"
+    assert var.get() == "finished"
+```
+
+Needless to say, this is a sharp tool. Do not wrap `start.as_coroutine()` in `context.run()` and do not also pass the
+same `context` to `asyncio.create_task(..., context=context)`, because `CoroStart` already uses that context when it
+resumes the coroutine. If you only need ordinary task context propagation, use `copy_context()` or the normal eager task
+helpers instead.
+
 ### Context helper
 
 `coro_await()` is a helper function to await a coroutine, optionally with a `contextvars.Context`

--- a/src/asynkit/_cext/corostart.c
+++ b/src/asynkit/_cext/corostart.c
@@ -1337,10 +1337,28 @@ static PyObject *cext_get_build_info(PyObject *_self)
     return info;
 }
 
+static PyObject *cext_get_current_context(PyObject *_self)
+{
+    (void) _self;
+    PyThreadState *tstate = PyThreadState_Get();
+    PyObject *context = tstate->context;
+    if(context == NULL) {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "the current context object is not available");
+        return NULL;
+    }
+    Py_INCREF(context);
+    return context;
+}
+
 static PyMethodDef module_methods[] = {{"get_build_info",
                                         (PyCFunction) cext_get_build_info,
                                         METH_NOARGS,
                                         "Get build configuration information"},
+                                       {"get_current_context",
+                                        (PyCFunction) cext_get_current_context,
+                                        METH_NOARGS,
+                                        "Get the live current context object"},
                                        {NULL, NULL, 0, NULL}};
 
 /* Module slots for GIL configuration */

--- a/src/asynkit/_cext/corostart.c
+++ b/src/asynkit/_cext/corostart.c
@@ -1341,6 +1341,11 @@ static PyObject *cext_get_current_context(PyObject *_self)
 {
     (void) _self;
     PyThreadState *tstate = PyThreadState_Get();
+    if(tstate == NULL) {
+        PyErr_SetString(PyExc_NotImplementedError,
+                        "the current thread state is not available");
+        return NULL;
+    }
     PyObject *context = tstate->context;
     if(context == NULL) {
         PyErr_SetString(PyExc_NotImplementedError,

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -147,7 +147,6 @@ class CAwaitable(Awaitable[T_co], Cancellable, Protocol):
     pass
 
 
-
 """
 Tools and utilities for advanced management of coroutines
 """

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -39,7 +39,7 @@ try:
     from ._cext import CoroStartBase as _CCoroStartBase  # type: ignore[attr-defined]
     from ._cext import get_build_info as _get_c_build_info  # type: ignore[attr-defined]
 
-    _cext_module = importlib.import_module("asynkit._cext")
+    _cext_module = importlib.import_module("._cext", __package__)
     _get_c_current_context = getattr(_cext_module, "get_current_context", None)
 
     _HAVE_C_EXTENSION = (

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
+import importlib
 import inspect
 import sys
 import types
@@ -22,7 +23,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
-    TypeAlias,
     TypeVar,
     cast,
     overload,
@@ -39,12 +39,16 @@ try:
     from ._cext import CoroStartBase as _CCoroStartBase  # type: ignore[attr-defined]
     from ._cext import get_build_info as _get_c_build_info  # type: ignore[attr-defined]
 
+    _cext_module = importlib.import_module("asynkit._cext")
+    _get_c_current_context = getattr(_cext_module, "get_current_context", None)
+
     _HAVE_C_EXTENSION = (
         True  # Re-enabled - C extension now has continued/pending methods
     )
 except ImportError:
     _CCoroStartBase = None
     _get_c_build_info = None
+    _get_c_current_context = None
     _HAVE_C_EXTENSION = False
 
 
@@ -98,6 +102,7 @@ __all__ = [
     "func_eager",
     "eager",
     "eager_ctx",
+    "get_current_context",
     "get_implementation_info",
     "create_eager_task_factory",
     "eager_task_factory",
@@ -116,6 +121,19 @@ __all__ = [
     "syncfunction",
 ]
 
+
+def get_current_context() -> Context:
+    """Return the live current context object.
+
+    This uses a CPython implementation detail and may not be available when the
+    C extension is missing or on Python implementations that do not expose the
+    current context object. Use `copy_context()` when a snapshot is sufficient.
+    """
+    if _get_c_current_context is None:
+        raise NotImplementedError("the live current context is not available")
+    return cast(Context, _get_c_current_context())
+
+
 T = TypeVar("T")
 S = TypeVar("S")
 P = ParamSpec("P")
@@ -128,8 +146,6 @@ Suspendable = (
 class CAwaitable(Awaitable[T_co], Cancellable, Protocol):
     pass
 
-
-Future_Type: TypeAlias = Future
 
 
 """
@@ -523,7 +539,7 @@ class CoroStartMixin(Generic[T_co]):
         """
         return await self
 
-    def as_future(self) -> Future_Type[T_co]:
+    def as_future(self) -> Future[T_co]:
         """
         if `done()` convert the result of the coroutine into a `Future`
         and return it.  Otherwise raise a `RuntimeError`

--- a/tests/test_eager_task_factory_context.py
+++ b/tests/test_eager_task_factory_context.py
@@ -14,6 +14,18 @@ import asynkit
 import asynkit.coroutine
 
 
+def live_current_context_available() -> bool:
+    probe = contextvars.ContextVar("live_current_context_available")
+    token = probe.set(True)
+    try:
+        asynkit.get_current_context()
+    except NotImplementedError:
+        return False
+    finally:
+        probe.reset(token)
+    return True
+
+
 class TestEagerTaskFactoryContext:
     """Test context behavior in eager task factory."""
 
@@ -178,6 +190,59 @@ class TestEagerTaskFactoryContext:
 
         finally:
             loop.set_task_factory(old_factory)
+
+    async def test_explicit_current_context_shared_with_task_continuation(
+        self, implementations
+    ):
+        """Test explicit current context use shares task continuation changes."""
+        if not live_current_context_available():
+            pytest.skip("live current context requires the C extension helper")
+
+        for impl_name, impl_class in implementations:
+            original = asynkit.coroutine.CoroStart
+            asynkit.coroutine.CoroStart = impl_class
+            try:
+                await self._test_explicit_shared_context(impl_name)
+            finally:
+                asynkit.coroutine.CoroStart = original
+
+    async def _test_explicit_shared_context(self, impl_name: str):
+        self.test_var.set("creator_value")
+        shared_context = asynkit.get_current_context()
+        observations = []
+
+        async def blocking_task():
+            observations.append(("initial", self.test_var.get()))
+            assert self.test_var.get() == "creator_value"
+            self.test_var.set("before_sleep")
+            await asyncio.sleep(0)
+            observations.append(("after_sleep", self.test_var.get()))
+            assert self.test_var.get() == "before_sleep"
+            self.test_var.set("after_sleep")
+            return "done"
+
+        cs = asynkit.coroutine.CoroStart(
+            blocking_task(), context=shared_context, autostart=False
+        )
+        assert cs.start() is False
+        assert self.test_var.get() == "before_sleep"
+
+        task = asyncio.create_task(cs.as_coroutine())
+        result = await task
+
+        assert result == "done"
+        assert self.test_var.get() == "after_sleep"
+        assert observations == [
+            ("initial", "creator_value"),
+            ("after_sleep", "before_sleep"),
+        ], impl_name
+
+    async def test_get_current_context_raises_without_c_helper(self, monkeypatch):
+        """Test pure Python fallback reports unavailable live context."""
+
+        monkeypatch.setattr(asynkit.coroutine, "_get_c_current_context", None)
+        with pytest.raises(NotImplementedError):
+            asynkit.get_current_context()
 
     async def test_context_inheritance_with_provided_context(self, implementations):
         """


### PR DESCRIPTION
## Summary

- Add experimental `get_current_context()` support through the CPython C extension.
- Expose a Python wrapper that raises `NotImplementedError` when the helper is unavailable.
- Add explicit `CoroStart` tests showing a shared live context can be used across eager start and remote Task continuation.
- Document the sharp edges and add an Unreleased changelog entry.

## Verification

- `mdformat --check --number CHANGES.md README.md`
- `ruff check src/asynkit/coroutine.py tests/test_eager_task_factory_context.py`
- `mypy -p asynkit -p tests -p examples`
- `pytest tests/test_eager_task_factory_context.py -q`