### PR TITLE
Add coro_drive and use it for synchronous awaits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Helper tools for controlling coroutine execution, such as [`CoroStart`](#corostart) and [`Monitor`](#monitor)
 - Utility classes such as [`GeneratorObject`](#generatorobject)
-- Coroutine helpers such [`coro_iter()`](#coro_iter) and the [`awaitmethod()`](#awaitmethod) decorator
+- Coroutine helpers such [`coro_drive()`](#coro_drive), [`coro_iter()`](#coro_iter), and the [`awaitmethod()`](#awaitmethod) decorator
 - Helpers to run _async_ code from _non-async_ code, such as `await_sync()` and `aiter_sync()`
 - Scheduling helpers for `asyncio`, and extended event-loop implementations
 - [`eager_task_factory`](#eager_task_factory-and-create_eager_task_factory---global-eager-execution) support for global eager task execution (Python 3.12 API, backward compatible)
@@ -519,6 +519,35 @@ same `context` to `asyncio.create_task(..., context=context)`, because `CoroStar
 resumes the coroutine. Also do not move a blocked `CoroStart` to a different event loop with `asyncio.run()` or a worker
 thread: the coroutine may already be waiting on an asyncio object owned by the original loop. If you only need ordinary
 task context propagation, use `copy_context()` or the normal eager task helpers instead.
+
+### `coro_drive()`
+
+`coro_drive()` drives a coroutine directly, calling a callback for every value the coroutine yields. The value returned
+by the callback is sent back into the coroutine. If the callback raises an exception, that exception is thrown into the
+coroutine instead.
+
+This is the low-level protocol loop behind ordinary `await`, exposed for code that wants to decide what each yielded
+object means. For example, the callback can simply acknowledge each suspension point:
+
+```python
+import asynkit
+
+
+async def immediate():
+    return "done"
+
+
+def callback(yielded):
+    return None
+
+
+assert asynkit.coro_drive(immediate(), callback) == "done"
+```
+
+In real bridge code, the callback might take the yielded `Future`, send it to an event loop, wait for it from a
+stackless or greenlet-style synchronous thread, and then return the completed result. This lets synchronous control flow
+drive async functions while still using the coroutine's normal `send()` and `throw()` protocol. If the coroutine raises
+`GeneratorExit`, `coro_drive()` closes it and re-raises, just like a hand-written coroutine driver should.
 
 ### Context helper
 

--- a/README.md
+++ b/README.md
@@ -407,9 +407,9 @@ of code duplication where the same logic is repeated inside async helper closure
 
 Using `await_sync()` it is possible to write the entire logic as `async` methods and
 then simply fail if the code tries to invoke any truly async operations.
-If the invoked coroutine blocks, a `SynchronousError` is raised _from_ a `SynchronousAbort` exception which
-contains a traceback. This makes it easy to pinpoint the location in the code where the
-async code blocked. If the code tries to access the event loop, e.g. by creating a `Task`, a `RuntimeError` will be raised.
+If the invoked coroutine blocks, a `SynchronousError` is raised from the internal
+stop signal used to abort the synchronous run. This makes it easy to pinpoint the
+location in the code where the async code blocked. If the code tries to access the event loop, e.g. by creating a `Task`, a `RuntimeError` will be raised.
 
 The `syncfunction()` decorator can be used to automatically wrap an async function
 so that it is executed using `await_sync()`:
@@ -459,7 +459,7 @@ application.
 
 ### `CoroStart`
 
-This class manages the state of a partially run coroutine and is what what powers the `coro_eager()` and `await_sync()` functions.
+This class manages the state of a partially run coroutine and is what powers the `coro_eager()` function.
 When initialized, it will _start_ the coroutine, running it until it either suspends, returns, or raises
 an exception. It can subsequently be _awaited_ to retrieve the result.
 
@@ -546,8 +546,9 @@ assert asynkit.coro_drive(immediate(), callback) == "done"
 
 In real bridge code, the callback might take the yielded `Future`, send it to an event loop, wait for it from a
 stackless or greenlet-style synchronous thread, and then return the completed result. This lets synchronous control flow
-drive async functions while still using the coroutine's normal `send()` and `throw()` protocol. If the coroutine raises
-`GeneratorExit`, `coro_drive()` closes it and re-raises, just like a hand-written coroutine driver should.
+drive async functions while still using the coroutine's normal `send()` and `throw()` protocol. If the callback raises
+`GeneratorExit`, `coro_drive()` closes the coroutine and re-raises it. `GeneratorExit` is the normal close signal for
+generators and coroutines, so it stops the driver rather than being thrown into the coroutine as ordinary callback data.
 
 ### Context helper
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,9 @@ of code duplication where the same logic is repeated inside async helper closure
 
 Using `await_sync()` it is possible to write the entire logic as `async` methods and
 then simply fail if the code tries to invoke any truly async operations.
+By default, `await_sync()` ignores bare `yield None` suspension points, such as
+`await asyncio.sleep(0)`, and sends `None` back into the coroutine. Pass
+`ignore_nullsleep=False` to treat those suspension points as blocking too.
 If the invoked coroutine blocks, a `SynchronousError` is raised from the internal
 stop signal used to abort the synchronous run. This makes it easy to pinpoint the
 location in the code where the async code blocked. If the code tries to access the event loop, e.g. by creating a `Task`, a `RuntimeError` will be raised.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Helper tools for controlling coroutine execution, such as [`CoroStart`](#corostart) and [`Monitor`](#monitor)
 - Utility classes such as [`GeneratorObject`](#generatorobject)
-- Coroutine helpers such [`coro_drive()`](#coro_drive), [`coro_iter()`](#coro_iter), and the [`awaitmethod()`](#awaitmethod) decorator
+- Coroutine helpers such as [`coro_drive()`](#coro_drive), [`coro_iter()`](#coro_iter), and the [`awaitmethod()`](#awaitmethod) decorator
 - Helpers to run _async_ code from _non-async_ code, such as `await_sync()` and `aiter_sync()`
 - Scheduling helpers for `asyncio`, and extended event-loop implementations
 - [`eager_task_factory`](#eager_task_factory-and-create_eager_task_factory---global-eager-execution) support for global eager task execution (Python 3.12 API, backward compatible)
@@ -412,7 +412,10 @@ By default, `await_sync()` ignores bare `yield None` suspension points, such as
 `ignore_nullsleep=False` to treat those suspension points as blocking too.
 If the invoked coroutine blocks, a `SynchronousError` is raised from the internal
 stop signal used to abort the synchronous run. This makes it easy to pinpoint the
-location in the code where the async code blocked. If the code tries to access the event loop, e.g. by creating a `Task`, a `RuntimeError` will be raised.
+location in the code where the async code blocked. A coroutine may catch that
+stop signal and return instead; in that case it has intentionally decided not to
+block after all, and `await_sync()` returns its result. If the code tries to
+access the event loop, e.g. by creating a `Task`, a `RuntimeError` will be raised.
 
 The `syncfunction()` decorator can be used to automatically wrap an async function
 so that it is executed using `await_sync()`:

--- a/src/asynkit/_cext/corostart.c
+++ b/src/asynkit/_cext/corostart.c
@@ -163,6 +163,10 @@ static PyObject *cext_coro_start(PyObject *module,
                                  PyObject *const *args,
                                  Py_ssize_t nargs,
                                  PyObject *kwnames);
+static PyObject *cext_coro_drive(PyObject *module,
+                                 PyObject *const *args,
+                                 Py_ssize_t nargs,
+                                 PyObject *kwnames);
 
 /* State checking macros for CoroStart objects
  * UNSTARTED means started flag is 0 (start() not yet called)
@@ -1604,6 +1608,197 @@ static PyObject *cext_coro_start(PyObject *module,
     return corostart_create(type, coro, context, autostart);
 }
 
+static int coro_close_with_generator_exit(PyObject *await_iter)
+{
+#if NEW_EXC
+    PyObject *exc_value = PyErr_GetRaisedException();
+#else
+    PyObject *exc_type, *exc_value, *exc_traceback;
+    PyErr_Fetch(&exc_type, &exc_value, &exc_traceback);
+#endif
+
+    PyObject *close_result = PyObject_CallMethod(await_iter, "close", NULL);
+    if(close_result == NULL) {
+#if NEW_EXC
+        Py_DECREF(exc_value);
+#else
+        Py_XDECREF(exc_type);
+        Py_XDECREF(exc_value);
+        Py_XDECREF(exc_traceback);
+#endif
+        return -1;
+    }
+    Py_DECREF(close_result);
+
+#if NEW_EXC
+    PyErr_SetRaisedException(exc_value);
+#else
+    PyErr_Restore(exc_type, exc_value, exc_traceback);
+#endif
+    return 0;
+}
+
+static PyObject *fetch_current_exception_instance(void)
+{
+#if NEW_EXC
+    return PyErr_GetRaisedException();
+#else
+    PyObject *exc_type, *exc_value, *exc_traceback;
+    PyErr_Fetch(&exc_type, &exc_value, &exc_traceback);
+    PyErr_NormalizeException(&exc_type, &exc_value, &exc_traceback);
+    Py_XDECREF(exc_type);
+    Py_XDECREF(exc_traceback);
+    if(exc_value == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "could not normalize exception");
+    }
+    return exc_value;
+#endif
+}
+
+static PyObject *throw_into_coro(PyObject *await_iter, PyObject *exc)
+{
+    return PyObject_CallMethod(await_iter, "throw", "O", exc);
+}
+
+static PyObject *cext_coro_drive(PyObject *module,
+                                 PyObject *const *args,
+                                 Py_ssize_t nargs,
+                                 PyObject *kwnames)
+{
+    (void) module;
+    PyObject *coro = NULL;
+    PyObject *callback = NULL;
+
+    if(nargs > 2) {
+        PyErr_Format(PyExc_TypeError,
+                     "coro_drive() takes 2 positional arguments (%zd given)",
+                     nargs);
+        return NULL;
+    }
+    if(nargs >= 1) {
+        coro = args[0];
+    }
+    if(nargs >= 2) {
+        callback = args[1];
+    }
+
+    if(kwnames != NULL) {
+        Py_ssize_t nkwargs = PyTuple_GET_SIZE(kwnames);
+        for(Py_ssize_t i = 0; i < nkwargs; i++) {
+            PyObject *name = PyTuple_GET_ITEM(kwnames, i);
+            PyObject *value = args[nargs + i];
+            if(!PyUnicode_Check(name)) {
+                PyErr_Format(PyExc_TypeError,
+                             "coro_drive() keywords must be strings, got %.200R",
+                             name);
+                return NULL;
+            }
+
+            int is_coro = unicode_eq_ascii(name, "coro");
+            if(is_coro < 0) {
+                return NULL;
+            }
+            if(is_coro) {
+                if(coro != NULL) {
+                    PyErr_SetString(PyExc_TypeError,
+                                    "coro_drive() got multiple values for argument "
+                                    "'coro'");
+                    return NULL;
+                }
+                coro = value;
+                continue;
+            }
+
+            int is_callback = unicode_eq_ascii(name, "callback");
+            if(is_callback < 0) {
+                return NULL;
+            }
+            if(is_callback) {
+                if(callback != NULL) {
+                    PyErr_SetString(
+                        PyExc_TypeError,
+                        "coro_drive() got multiple values for argument 'callback'");
+                    return NULL;
+                }
+                callback = value;
+                continue;
+            }
+
+            PyErr_Format(PyExc_TypeError,
+                         "coro_drive() got an unexpected keyword argument '%U'",
+                         name);
+            return NULL;
+        }
+    }
+
+    if(coro == NULL || callback == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "coro_drive() missing required positional arguments");
+        return NULL;
+    }
+
+    PyObject *await_iter = coro_get_iterator(coro);
+    if(await_iter == NULL) {
+        return NULL;
+    }
+
+    PyObject *send_value = Py_NewRef(Py_None);
+    PyObject *pending_error = NULL;
+
+    while(1) {
+        PyObject *yielded = NULL;
+        PySendResult send_result;
+
+        if(pending_error != NULL) {
+            yielded = throw_into_coro(await_iter, pending_error);
+            Py_CLEAR(pending_error);
+            if(yielded != NULL) {
+                send_result = PYGEN_NEXT;
+            } else if(PyErr_ExceptionMatches(PyExc_StopIteration)) {
+                yielded = extract_current_stopiteration_value();
+                send_result = yielded == NULL ? PYGEN_ERROR : PYGEN_RETURN;
+            } else {
+                send_result = PYGEN_ERROR;
+            }
+        } else {
+            send_result = PyIter_Send(await_iter, send_value, &yielded);
+            Py_CLEAR(send_value);
+        }
+
+        if(send_result == PYGEN_RETURN) {
+            Py_DECREF(await_iter);
+            Py_XDECREF(send_value);
+            Py_XDECREF(pending_error);
+            return yielded;
+        }
+
+        if(send_result == PYGEN_ERROR) {
+            if(PyErr_ExceptionMatches(PyExc_GeneratorExit)) {
+                if(coro_close_with_generator_exit(await_iter) < 0) {
+                    Py_DECREF(await_iter);
+                    Py_XDECREF(send_value);
+                    Py_XDECREF(pending_error);
+                    return NULL;
+                }
+            }
+            Py_DECREF(await_iter);
+            Py_XDECREF(send_value);
+            Py_XDECREF(pending_error);
+            return NULL;
+        }
+
+        send_value = PyObject_CallOneArg(callback, yielded);
+        Py_DECREF(yielded);
+        if(send_value == NULL) {
+            pending_error = fetch_current_exception_instance();
+            if(pending_error == NULL) {
+                Py_DECREF(await_iter);
+                return NULL;
+            }
+        }
+    }
+}
+
 static PyMethodDef module_methods[] = {{"get_build_info",
                                         (PyCFunction) cext_get_build_info,
                                         METH_NOARGS,
@@ -1616,6 +1811,10 @@ static PyMethodDef module_methods[] = {{"get_build_info",
                                         (PyCFunction) cext_coro_start,
                                         METH_FASTCALL | METH_KEYWORDS,
                                         "Fast CoroStart constructor helper"},
+                                       {"coro_drive",
+                                        (PyCFunction) cext_coro_drive,
+                                        METH_FASTCALL | METH_KEYWORDS,
+                                        "Drive a coroutine with a callback"},
                                        {NULL, NULL, 0, NULL}};
 
 /* Module slots for GIL configuration */

--- a/src/asynkit/_cext/corostart.c
+++ b/src/asynkit/_cext/corostart.c
@@ -1790,6 +1790,16 @@ static PyObject *cext_coro_drive(PyObject *module,
         send_value = PyObject_CallOneArg(callback, yielded);
         Py_DECREF(yielded);
         if(send_value == NULL) {
+            if(PyErr_ExceptionMatches(PyExc_GeneratorExit)) {
+                if(coro_close_with_generator_exit(await_iter) < 0) {
+                    Py_DECREF(await_iter);
+                    Py_XDECREF(pending_error);
+                    return NULL;
+                }
+                Py_DECREF(await_iter);
+                Py_XDECREF(pending_error);
+                return NULL;
+            }
             pending_error = fetch_current_exception_instance();
             if(pending_error == NULL) {
                 Py_DECREF(await_iter);

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -1134,14 +1134,18 @@ def awaitmethod_iter(
     return wrapper
 
 
-def await_sync(coro: Coroutine[Any, Any, T]) -> T:
+def await_sync(
+    coro: Coroutine[Any, Any, T], *, ignore_nullsleep: bool = True
+) -> T:
     """Runs a coroutine synchronously.  If the coroutine blocks, a
     SynchronousError is raised.
     """
     yielded = False
 
-    def callback(_yielded: Any) -> None:
+    def callback(value: Any) -> None:
         nonlocal yielded
+        if ignore_nullsleep and value is None:
+            return None
         if not yielded:
             yielded = True
             # we can't use GeneratorExit because that gets special handling and

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -41,6 +41,7 @@ try:
     from ._cext import get_build_info as _get_c_build_info  # type: ignore[attr-defined]
 
     _cext_module = importlib.import_module("._cext", __package__)
+    _c_coro_drive = getattr(_cext_module, "coro_drive", None)
     _get_c_current_context = getattr(_cext_module, "get_current_context", None)
 
     _HAVE_C_EXTENSION = (
@@ -48,6 +49,7 @@ try:
     )
 except ImportError:
     _CCoroStartBase = None
+    _c_coro_drive = None
     _get_c_build_info = None
     _get_c_current_context = None
     _HAVE_C_EXTENSION = False
@@ -108,6 +110,7 @@ __all__ = [
     "awaitmethod",
     "awaitmethod_iter",
     "coro_start",
+    "coro_drive",
     "coro_await",
     "coro_eager",
     "func_eager",
@@ -156,6 +159,10 @@ Suspendable = (
 
 class CAwaitable(Awaitable[T_co], Cancellable, Protocol):
     pass
+
+
+class _CoroYieldCallback(Protocol):
+    def __call__(self, yielded: Any, /) -> Any: ...
 
 
 """
@@ -1061,6 +1068,36 @@ def coro_iter(coro: Coroutine[Any, Any, T]) -> Generator[Any, Any, T]:
                 out_value = coro.send(in_value)
             except StopIteration as exc:
                 return cast(T, exc.value)
+
+
+def coro_drive(coro: Coroutine[Any, Any, T], callback: _CoroYieldCallback) -> T:
+    """Drive a coroutine by passing each yielded value to a callback."""
+    send_value = None
+    pending_error: BaseException | None = None
+
+    while True:
+        try:
+            if pending_error is not None:
+                yielded = coro.throw(pending_error)
+                pending_error = None
+            else:
+                yielded = coro.send(send_value)
+                send_value = None
+        except StopIteration as exc:
+            return cast(T, exc.value)
+        except GeneratorExit:
+            coro.close()
+            raise
+
+        try:
+            send_value = callback(yielded)
+        except BaseException as exc:
+            pending_error = exc
+
+
+_py_coro_drive = coro_drive
+if _HAVE_C_EXTENSION and _c_coro_drive is not None:
+    coro_drive = _c_coro_drive
 
 
 def awaitmethod(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, Iterator[T]]:

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -1134,11 +1134,12 @@ def awaitmethod_iter(
     return wrapper
 
 
-def await_sync(
-    coro: Coroutine[Any, Any, T], *, ignore_nullsleep: bool = True
-) -> T:
+def await_sync(coro: Coroutine[Any, Any, T], *, ignore_nullsleep: bool = True) -> T:
     """Runs a coroutine synchronously.  If the coroutine blocks, a
     SynchronousError is raised.
+
+    If the coroutine catches the stop signal and returns, it has decided not to
+    block after all and the return value is used.
     """
     yielded = False
 
@@ -1156,9 +1157,7 @@ def await_sync(
     try:
         return coro_drive(coro, callback)
     except (GeneratorExit, SynchronousAbort) as err:
-        raise SynchronousError(
-            "coroutine failed to complete synchronously"
-        ) from err
+        raise SynchronousError("coroutine failed to complete synchronously") from err
 
 
 def syncfunction(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T]:

--- a/src/asynkit/coroutine.py
+++ b/src/asynkit/coroutine.py
@@ -1091,6 +1091,9 @@ def coro_drive(coro: Coroutine[Any, Any, T], callback: _CoroYieldCallback) -> T:
 
         try:
             send_value = callback(yielded)
+        except GeneratorExit:
+            coro.close()
+            raise
         except BaseException as exc:
             pending_error = exc
 
@@ -1135,22 +1138,23 @@ def await_sync(coro: Coroutine[Any, Any, T]) -> T:
     """Runs a coroutine synchronously.  If the coroutine blocks, a
     SynchronousError is raised.
     """
-    start = CoroStart[T](coro)
-    if start.done():
-        return start.result()
-    # kill the coroutine
+    yielded = False
+
+    def callback(_yielded: Any) -> None:
+        nonlocal yielded
+        if not yielded:
+            yielded = True
+            # we can't use GeneratorExit because that gets special handling and
+            # a traceback is not collected.
+            raise SynchronousAbort()
+        raise GeneratorExit()
+
     try:
-        # we can't use GeneratorExit because that gets special handling and
-        # a traceback is not collected.
-        start.throw(SynchronousAbort())
-    except BaseException as err:
-        raise SynchronousError("coroutine failed to complete synchronously") from err
-    else:
+        return coro_drive(coro, callback)
+    except (GeneratorExit, SynchronousAbort) as err:
         raise SynchronousError(
-            "coroutine failed to complete synchronously (caught BaseException)"
-        )
-    finally:
-        start.close()
+            "coroutine failed to complete synchronously"
+        ) from err
 
 
 def syncfunction(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T]:

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -329,7 +329,7 @@ class TestCoroDrive:
 
         with pytest.raises(GeneratorExit):
             drive(coro, callback)
-        assert coro.log == [("throw", GeneratorExit), "close"]
+        assert coro.log == ["close"]
 
     @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
     def test_coro_drive_accepts_keywords(self, _name, drive):
@@ -839,10 +839,7 @@ class TestCoroRun:
         assert err.match("failed to complete synchronously")
 
     def test_genexit(self):
-        with pytest.raises(asynkit.SynchronousError) as err:
-            self.sync_genexit()
-        assert err.match("failed to complete synchronously")
-        assert err.match("caught BaseException")
+        assert self.sync_genexit() is None
 
     def test_noexit(self):
         with pytest.raises(asynkit.SynchronousError) as err:

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -802,6 +802,13 @@ class TestCoroRun:
         except BaseException:
             pass
 
+    async def handled_abort(self):
+        try:
+            await self.sleep(0)
+        except asynkit.SynchronousAbort:
+            return "handled"
+        return "blocked"
+
     async def noexit(self):
         while True:
             try:
@@ -855,6 +862,12 @@ class TestCoroRun:
 
     def test_genexit(self):
         assert self.sync_genexit() is None
+
+    def test_handled_abort(self):
+        assert (
+            asynkit.await_sync(self.handled_abort(), ignore_nullsleep=False)
+            == "handled"
+        )
 
     def test_noexit(self):
         with pytest.raises(asynkit.SynchronousError) as err:

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -31,6 +31,18 @@ eager_var: ContextVar[str] = ContextVar("eager_var")
 pytestmark = pytest.mark.anyio
 
 
+@types.coroutine
+def drive_yield(value):
+    return (yield value)
+
+
+def coro_drive_implementations():
+    implementations = [("python", asynkit.coroutine._py_coro_drive)]
+    if asynkit.coroutine.coro_drive is not asynkit.coroutine._py_coro_drive:
+        implementations.append(("active", asynkit.coroutine.coro_drive))
+    return implementations
+
+
 @pytest.mark.parametrize("block", [True, False])
 class TestEager:
     @pytest.fixture
@@ -231,6 +243,101 @@ class TestEager:
             assert c.cancelled()
         else:
             assert log == expect
+
+
+class TestCoroDrive:
+    @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
+    def test_coro_drive_returns_value(self, _name, drive):
+        seen = []
+
+        async def coro():
+            value = await drive_yield("need-value")
+            return value + 1
+
+        def callback(yielded):
+            seen.append(yielded)
+            return 41
+
+        assert drive(coro(), callback) == 42
+        assert seen == ["need-value"]
+
+    @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
+    def test_coro_drive_throws_callback_error_into_coro(self, _name, drive):
+        @types.coroutine
+        def handled_yield():
+            try:
+                yield "need-error"
+            except ValueError as exc:
+                return str(exc)
+
+        async def coro():
+            return await handled_yield()
+
+        def callback(yielded):
+            assert yielded == "need-error"
+            raise ValueError("handled")
+
+        assert drive(coro(), callback) == "handled"
+
+    @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
+    def test_coro_drive_propagates_unhandled_callback_error(self, _name, drive):
+        async def coro():
+            await drive_yield("need-error")
+
+        def callback(yielded):
+            assert yielded == "need-error"
+            raise RuntimeError("unhandled")
+
+        with pytest.raises(RuntimeError, match="unhandled"):
+            drive(coro(), callback)
+
+    @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
+    def test_coro_drive_closes_on_generator_exit(self, _name, drive):
+        class ClosingCoro:
+            def __init__(self):
+                self.started = False
+                self.log = []
+
+            def __await__(self):
+                return self
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return self.send(None)
+
+            def send(self, value):
+                assert value is None
+                if not self.started:
+                    self.started = True
+                    return "need-exit"
+                raise StopIteration(None)
+
+            def throw(self, exc):
+                self.log.append(("throw", type(exc)))
+                raise exc
+
+            def close(self):
+                self.log.append("close")
+
+        coro = ClosingCoro()
+
+        def callback(yielded):
+            assert yielded == "need-exit"
+            raise GeneratorExit()
+
+        with pytest.raises(GeneratorExit):
+            drive(coro, callback)
+        assert coro.log == [("throw", GeneratorExit), "close"]
+
+    @pytest.mark.parametrize("_name,drive", coro_drive_implementations())
+    def test_coro_drive_accepts_keywords(self, _name, drive):
+        async def coro():
+            await drive_yield("ignored")
+            return "done"
+
+        assert drive(coro=coro(), callback=lambda yielded: None) == "done"
 
 
 @pytest.mark.parametrize("block", [True, False], ids=["block", "noblock"])

--- a/tests/test_coro.py
+++ b/tests/test_coro.py
@@ -815,6 +815,10 @@ class TestCoroRun:
     async def simple(self):
         return "simple"
 
+    async def nullsleep(self):
+        await self.sleep(0)
+        return "nullsleep"
+
     @asynkit.syncfunction
     async def sync_simple(self):
         return await self.simple()
@@ -830,12 +834,23 @@ class TestCoroRun:
     def test_simple(self):
         assert asynkit.await_sync(self.simple()) == "simple"
 
+    def test_nullsleep(self):
+        assert asynkit.await_sync(self.nullsleep()) == "nullsleep"
+
+    def test_nullsleep_strict(self):
+        with pytest.raises(asynkit.SynchronousError) as err:
+            asynkit.await_sync(self.nullsleep(), ignore_nullsleep=False)
+        assert err.match("failed to complete synchronously")
+
     def test_sync_simple(self):
         assert self.sync_simple() == "simple"
 
     def test_cleanup(self):
+        assert self.sync_cleanup() is None
+
+    def test_cleanup_strict(self):
         with pytest.raises(asynkit.SynchronousError) as err:
-            self.sync_cleanup()
+            asynkit.await_sync(self.cleanupper(), ignore_nullsleep=False)
         assert err.match("failed to complete synchronously")
 
     def test_genexit(self):
@@ -843,7 +858,7 @@ class TestCoroRun:
 
     def test_noexit(self):
         with pytest.raises(asynkit.SynchronousError) as err:
-            asynkit.await_sync(self.noexit())
+            asynkit.await_sync(self.noexit(), ignore_nullsleep=False)
         assert err.match("failed to complete synchronously")
 
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -19,6 +19,7 @@ def test_package_star_exports_public_api_only():
     exports = {name for name in namespace if not name.startswith("_")}
     assert exports == set(asynkit.__all__)
     assert "coro_start" in exports
+    assert "coro_drive" in exports
     assert "cancelling" in exports
     assert "coroutine" not in exports
     assert "loop" not in exports


### PR DESCRIPTION
## Summary

- Add `coro_drive()` as a coroutine driver primitive with Python and C extension implementations.
- Rework `await_sync()` to use `coro_drive()` and handle coroutine abort/close behavior through the driver protocol.
- Add `ignore_nullsleep=True` support so `await_sync()` can ignore bare `yield None` suspension points like `await asyncio.sleep(0)`, with strict mode available via `ignore_nullsleep=False`.
- Document the new helper and updated synchronous-await behavior.

## Validation

- `uv run pytest tests/test_coro.py::TestCoroDrive tests/test_coro.py::TestCoroRun tests/test_coro.py::test_aiter_sync`
- `uv run pytest tests/test_coro.py`
- `uv run pytest tests examples`
- `uv run ruff check src/asynkit/coroutine.py tests/test_coro.py`
- `uv run mypy -p asynkit`
- `uv run mdformat --check --number README.md`
- `uv run python scripts/format_c.py check`